### PR TITLE
修复一些问题，新增一些功能以及仍存在的问题

### DIFF
--- a/report/literaturereview.tex
+++ b/report/literaturereview.tex
@@ -28,7 +28,7 @@
 
 %%%%%%%%%% 标题 %%%%%%%%%%
 \vspace*{3.0mm}
-\centerline{\sanhao\heiti\bfseries{浙江工业大学本科生毕业设计文献综述模板}}
+\centerline{\sanhao\heiti\bfseries\zjuttitlec}
 \vspace*{3.0mm}
 
 %%%%%%%%%% 摘要 %%%%%%%%%%

--- a/report/preface/cover.tex
+++ b/report/preface/cover.tex
@@ -5,7 +5,7 @@
 \thispagestyle{empty}
 \pdfbookmark[-1]{\zjuttitlec}{zjutreportcover}
 \phantomsection \label{zjutreportcover}
-\vspace*{4mm}
+\vspace*{-5mm}
 % 校名
 \begin{center}
    \includegraphics[width=98.40mm]{figures/zjut}
@@ -20,7 +20,7 @@
   \includegraphics[width=27.3mm]{figures/zjutlogo}
 \end{center}
 
-\vspace*{0.0mm}
+\vspace*{5mm}
 \renewcommand{\arraystretch}{1.0}
 \hspace*{12mm} 
 {\songti\erhao{论文题目}}
@@ -30,17 +30,17 @@
 \end{minipage}
 \vspace*{1mm}
 \begin{center}
-    \setlength{\arrayrulewidth}{0.5pt}
-    {\songti\sihao
-        \renewcommand{\arraystretch}{1}
-        \begin{tabular}{lc}
-            作者姓名\qquad &  \zjutauthornamec \\ \cline{2-2}
-            指导教师\qquad &  \zjutmentorc\\ \cline{2-2}
-            \\
-            学科(专业)\qquad &  \zjutmajor \\ \cline{2-2}
-            所在学院\qquad &  \zjutcollegec \\ \cline{2-2}
-            提交日期\qquad & \zjutsubmitteddatee \\ \cline{2-2}
-        \end{tabular}
-    }
+	\setlength{\arrayrulewidth}{0.5pt}
+	{\songti\sihao
+		\renewcommand{\arraystretch}{1}
+		\begin{tabular}{lc}
+			作者姓名\qquad &  \CJKunderline{\makebox[13em]{\zjutauthornamec}} \\
+			指导教师\qquad &  \CJKunderline{\makebox[13em]{\zjutmentorc}} \\ 
+			\\
+			学科(专业)\qquad &  \CJKunderline{\makebox[13em]{\zjutmajor}} \\
+			所在学院\qquad &  \CJKunderline{\makebox[13em]{\zjutcollegec}} \\ 
+			提交日期\qquad & \CJKunderline{\makebox[13em]{\zjutsubmitteddatee}} \\
+		\end{tabular}
+	}
 \end{center}
 

--- a/report/proposal.tex
+++ b/report/proposal.tex
@@ -28,7 +28,7 @@
 
 %%%%%%%%%% 标题 %%%%%%%%%%
 \vspace*{3.0mm}
-\centerline{\sanhao\heiti\bfseries{浙江工业大学本科生毕业设计开题报告模板}}
+\centerline{\sanhao\heiti\bfseries\zjuttitlec}
 \vspace*{3.0mm}
 
 %%%%%%%%%% 摘要 %%%%%%%%%%

--- a/report/translation.tex
+++ b/report/translation.tex
@@ -28,7 +28,7 @@
 
 %%%%%%%%%% 标题 %%%%%%%%%%
 \vspace*{3.0mm}
-\centerline{\sanhao\heiti\bfseries{浙江工业大学本科生毕业设计外文翻译模板}}
+\centerline{\sanhao\heiti\bfseries\zjuttitlec}
 \vspace*{3.0mm}
 
 %%%%%%%%%% 摘要 %%%%%%%%%%

--- a/report/zjutreport.cfg
+++ b/report/zjutreport.cfg
@@ -82,7 +82,6 @@
 \DeclareRobustCommand{\zjutdate}[1]{%
   \renewcommand{\zjutsubmitteddatee}{#1}}
 \DeclareRobustCommand{\zjutreport}{\textsc{ZJUT}\-\textsc{Report}}
-\DeclareRobustCommand{\thuthesis}{\textsc{Thu}\-\textsc{Thesis}}
 \endinput
 
 

--- a/report/zjutreport.cls
+++ b/report/zjutreport.cls
@@ -206,47 +206,36 @@
 %% http://mirror.bjtu.edu.cn/CTAN/macros/latex/contrib/titlesec/titlesec.pdf
 %%%%%%%%%%%%%%%%%%%%
 
-%%% 1级标题，四号，黑体，居中，加粗，段前12磅，段后6磅，1.5倍行距 {
+%%% 1级标题，四号，黑体
 \titleclass{\chapter}{straight}
-\titleformat{\chapter}[block]{\sihao\heiti\bfseries}{\ifzjut@translation{\thechapter}\else{\zhnumber{\thechapter}}\fi、}{1ex}{}{}
+\titleformat{\chapter}[block]{\onehalfspacing \sihao\heiti}{\ifzjut@translation{\thechapter}\else{\zhnumber{\thechapter}}\fi、}{1ex}{}{}
 \titlespacing{\chapter}{0pt}{-6pt}{0pt}
 \titlecontents{chapter}[0.1ex]
         {}
         {\songti\bfseries{\zhnumber{\thecontentslabel{}}、\hspace{1ex}}}
         {}
         {\titlerule*[5pt]{.}\contentspage}
-%%% }
 
-%%% 2级标题，小四，黑体，段前6磅，段后6磅，1.5倍行距 {
-\titleformat{\section}[hang]{\xiaosi\heiti}{\thesection}{1em}{}{}
-\titlespacing{\section}{0pt}{-3pt}{0pt}
+
+%%% 2级标题，小四，黑体
+\titleformat{\section}[hang]{\onehalfspacing \xiaosi\heiti}{\thesection}{1em}{}{}
+\titlespacing{\section}{0pt}{-15pt}{0pt}
 \titlecontents{section}[1.0ex]
         {}
         {\hspace{1em}\thecontentslabel\hspace{1em}}
         {}
         {\titlerule*[5pt]{.}\contentspage}
-%%% }
 
-%%% 3级标题，小四，黑体，段前段后６磅，1.5倍行距，建议不使用四级或更高级别目录、标题 {
-\titleformat{\subsection}[hang]{\xiaosi\heiti}{\thesubsection}{1em}{}{}
-\titlespacing{\subsection}{0pt}{-3pt}{0pt}
+
+%%% 3级标题，小四，黑体
+\titleformat{\subsection}[hang]{\onehalfspacing \xiaosi\heiti}{\thesubsection}{1em}{}{}
+\titlespacing{\subsection}{0pt}{-12pt}{0pt}
 \titlecontents{subsection}[1.0ex]
         {}
         {\hspace{2em}\thecontentslabel\hspace{1em}}
         {}
         {\titlerule*[5pt]{.}\contentspage}
-%%% }
 
-%%% 4级标题 DEPRECATED {
-\titleformat{\subsubsection}[hang]{\xiaosi\heiti\bfseries}{\thesubsubsection}{1em}{}{}
-\titlespacing{\subsubsection}{0pt}{0.0\baselineskip}{0.0\baselineskip}
-\titlecontents{subsubsection}[1.0ex]
-        {}
-        {\hspace{3em}\thecontentslabel\hspace{1em}}
-        {}
-        {\titlerule*[5pt]{.}\contentspage}
-
-%%% }
 
 %%% 中文摘要及关键词
 \newenvironment{abstractc}{
@@ -288,10 +277,10 @@
 \fancyfoot[C]{\xiaowu\thepage}
 %%% }
 
-\renewcommand{\figurename}{~\zjut@label@figurename~}
-\renewcommand{\thefigure}{~\thechapter-\arabic{figure}~}
-\renewcommand{\tablename}{~\zjut@label@tablename~}
-\renewcommand{\thetable}{~\thechapter-\arabic{table}~}
+\renewcommand{\figurename}{\zjut@label@figurename}
+\renewcommand{\thefigure}{\thechapter-\arabic{figure}}
+\renewcommand{\tablename}{\zjut@label@tablename}
+\renewcommand{\thetable}{\thechapter-\arabic{table}}
 
 \renewcommand{\algorithmcfname}{\zjut@label@algname}
 % \setlength{\belowcaptionskip}{2mm}
@@ -332,10 +321,11 @@
 %   \setlength{\bibhang}{2em} %每个条目自第二行起缩进的距离
 
 % 参考文献引用作为上标出现
-% \newcommand{\citeup}[1]{\textsuperscript{\cite{#1}}}
 \makeatletter
 \def\@cite#1#2{\textsuperscript{[{#1\if@tempswa , #2\fi}]}}
 \makeatother
+% 参考文献引用作为非下标出现
+\newcommand{\mycite}[1]{\scalebox{1.3}[1.3]{\raisebox{-0.65ex}{\cite{#1}}}}
 %% 引用格式
 \bibpunct{[}{]}{,}{s}{}{,}
 

--- a/thesis/zjutthesis.cfg
+++ b/thesis/zjutthesis.cfg
@@ -76,7 +76,6 @@
 \DeclareRobustCommand{\zjutdate}[1]{%
   \renewcommand{\zjutsubmitteddatee}{#1}}
 \DeclareRobustCommand{\zjutthesis}{\textsc{ZJUT}\-\textsc{Thesis}}
-\DeclareRobustCommand{\thuthesis}{\textsc{Thu}\-\textsc{Thesis}}
 \endinput
 
 

--- a/thesis/zjutthesis.cls
+++ b/thesis/zjutthesis.cls
@@ -1,6 +1,7 @@
 %%
 %% Copyright (C) 2008-09-24 by Wei-Wei Guo <wwguo@zju.edu.cn>
 %% Copyright (C) 2012-12-28 by Myau-tsai PAN <ibmmc@live.com>, Unlucky <unlucky1990@gmail.com>
+%% Copyright (C) 2023-01-19 by Ze Lin <zee_lin@foxmail.com>
 %% 
 %% This file may be distributed and/or modified under the conditions of
 %% the LaTeX Project Public License, either version 1.2 of this license
@@ -209,7 +210,7 @@
 
 %%% 2级标题，小三，宋体，加粗，段前12磅，段后6磅，1.5倍行距 {
 \titleformat{\section}[hang]{\onehalfspacing \xiaosan\songti\bfseries}{\thesection}{1em}{}{}
-\titlespacing{\section}{0pt}{-6pt}{6pt} % XXX 调整行距后@mckelvin 人工调的
+\titlespacing{\section}{0pt}{-6pt}{0pt} % XXX 调整行距后@mckelvin 人工调的
 \titlecontents{section}[1.0ex]
         {}
         {\wuhao\hspace{1ex}\thecontentslabel\hspace{1em}}
@@ -260,6 +261,9 @@
 }
 %%% }
 
+%%% 数学公式
+\renewcommand\theequation{\arabic{chapter}-\arabic{equation}}
+
 %%% 页眉页脚{
 \pagestyle{fancy}
 \fancyhf{}
@@ -280,8 +284,8 @@
 %%% 图目录
 \renewcommand{\listfigurename}{\centerline{\zjut@label@listfigurename}}
 \renewcommand{\numberline}[1]{\zjut@label@figurename~#1\hspace*{1em}}
-\renewcommand{\figurename}{~\zjut@label@figurename~}
-\renewcommand{\thefigure}{~\thechapter-\arabic{figure}~}
+\renewcommand{\figurename}{\zjut@label@figurename}
+\renewcommand{\thefigure}{\thechapter-\arabic{figure}}
 \titlecontents{figure}[0.1ex]
         {}
         {\wuhao{\zjut@label@figurename \thecontentslabel\hspace{0.5ex}}}
@@ -291,8 +295,8 @@
 %%% 表目录
 \renewcommand{\listtablename}{\centerline{\zjut@label@listtablename}}
 \renewcommand{\numberline}[1]{\zjut@label@tablename~#1\hspace*{1em}}
-\renewcommand{\tablename}{~\zjut@label@tablename~}
-\renewcommand{\thetable}{~\thechapter-\arabic{table}~}
+\renewcommand{\tablename}{\zjut@label@tablename}
+\renewcommand{\thetable}{\thechapter-\arabic{table}}
 \titlecontents{table}[0.1ex]
         {}
         {\wuhao{\zjut@label@tablename \thecontentslabel\hspace{0.5ex}}}
@@ -300,7 +304,8 @@
         {\wuhao\titlerule*[3pt]{.}\contentspage}
 
 \renewcommand{\algorithmcfname}{\zjut@label@algname}
-% \setlength{\belowcaptionskip}{2mm}
+\setlength\abovecaptionskip{0.5\baselineskip}
+\setlength\belowcaptionskip{-10pt}
 \renewcommand{\footnotesize}{\xiaowu}
 
 
@@ -346,10 +351,11 @@
 %   \setlength{\bibhang}{2em} %每个条目自第二行起缩进的距离
 
 % 参考文献引用作为上标出现
-% \newcommand{\citeup}[1]{\textsuperscript{\cite{#1}}}
 \makeatletter
 \def\@cite#1#2{\textsuperscript{[{#1\if@tempswa , #2\fi}]}}
 \makeatother
+% 参考文献引用作为非下标出现
+\newcommand{\mycite}[1]{\scalebox{1.3}[1.3]{\raisebox{-0.65ex}{\cite{#1}}}}
 %% 引用格式
 \bibpunct{[}{]}{,}{s}{}{,}
 


### PR DESCRIPTION
修复：图表标题的“图”或“表”字与编号之间距离过大的问题；图标题与下方正文距离过大的问题。
新增：数学公式以“章节-序号”表示；参考文献引用作为非下标出现。
仍存在的问题：表格与下方正文的距离仍然需要用`\vspace{-1.5em}`命令手动减小距离；二级标题与三级标题之间的距离有些大，仍然需要手动调整。